### PR TITLE
352 destroy routes

### DIFF
--- a/scripts/capture-cluster-state.sh
+++ b/scripts/capture-cluster-state.sh
@@ -7,10 +7,14 @@ EXCLUSIONS="$4"
 
 OUTFILE_DIR=$(dirname "${OUTFILE}")
 
+clusterType="${PLATFORM}"
+
 mkdir -p "${OUTFILE_DIR}"
 
 resources="deployment,statefulset,service,ingress,configmap,secret,serviceaccount"
 if [[ "$PLATFORM" == "openshift" ]] || [[ "$PLATFORM" == "ocp3" ]] || [[ "$PLATFORM" == "ocp4" ]]; then
+  clusterType="openshift"
+
   resources="${resources},route"
 
   if [[ "$PLATFORM" == "ocp4" ]]; then
@@ -21,6 +25,12 @@ fi
 echo "Checking on namespace - ${NAMESPACE}"
 
 if kubectl get namespace "${NAMESPACE}" 1> /dev/null 2> /dev/null; then
+
+  echo "deploy tool-test chart to namespace ${NAMESPACE}"
+  helm template mytest tool-test \
+    --repo "https://ibm-garage-cloud.github.io/toolkit-charts/" \
+    --version 0.1.0  \
+    --set global.clusterType=${clusterType} |  kubectl apply -n ${NAMESPACE} -f -
 
   echo "Listing resources in namespace - ${resources}"
   RESOURCES=$(kubectl get -n "${NAMESPACE}" "${resources}" -o jsonpath='{range .items[*]}{.metadata.namespace}{"/"}{.kind}{"/"}{.metadata.name}{"\n"}{end}' | tr '[:upper:]' '[:lower:]')

--- a/scripts/capture-cluster-state.sh
+++ b/scripts/capture-cluster-state.sh
@@ -26,8 +26,11 @@ echo "Checking on namespace - ${NAMESPACE}"
 
 if kubectl get namespace "${NAMESPACE}" 1> /dev/null 2> /dev/null; then
 
+  echo "install helm"
+  curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
+
   echo "deploy tool-test chart to namespace ${NAMESPACE}"
-  helm3 template destroytest tool-test \
+  helm template destroytest tool-test \
     --repo "https://ibm-garage-cloud.github.io/toolkit-charts/" \
     --version 0.1.0  \
     --set global.clusterType=${clusterType} |  kubectl apply -n ${NAMESPACE} -f -

--- a/scripts/capture-cluster-state.sh
+++ b/scripts/capture-cluster-state.sh
@@ -27,7 +27,7 @@ echo "Checking on namespace - ${NAMESPACE}"
 if kubectl get namespace "${NAMESPACE}" 1> /dev/null 2> /dev/null; then
 
   echo "deploy tool-test chart to namespace ${NAMESPACE}"
-  helm template destroytest tool-test \
+  helm3 template destroytest tool-test \
     --repo "https://ibm-garage-cloud.github.io/toolkit-charts/" \
     --version 0.1.0  \
     --set global.clusterType=${clusterType} |  kubectl apply -n ${NAMESPACE} -f -

--- a/scripts/capture-cluster-state.sh
+++ b/scripts/capture-cluster-state.sh
@@ -27,7 +27,7 @@ echo "Checking on namespace - ${NAMESPACE}"
 if kubectl get namespace "${NAMESPACE}" 1> /dev/null 2> /dev/null; then
 
   echo "deploy tool-test chart to namespace ${NAMESPACE}"
-  helm template mytest tool-test \
+  helm template destroytest tool-test \
     --repo "https://ibm-garage-cloud.github.io/toolkit-charts/" \
     --version 0.1.0  \
     --set global.clusterType=${clusterType} |  kubectl apply -n ${NAMESPACE} -f -


### PR DESCRIPTION
Fixes ibm-garage-cloud/planning#352

Use helm to deploy tool-test chart which installs a service and a route on OCP or an ingress on IKS. This verifies that the destroy doesn't delete this resources.